### PR TITLE
fixed error  'NodeJS.Timer' is not assignable to parameter of type 'string | number | Timeout | undefined'.

### DIFF
--- a/src/client/car.ts
+++ b/src/client/car.ts
@@ -26,7 +26,7 @@ export default class Car {
     private explosions: { [id: string]: Explosion } = {}
     //hasWon = false
     explosionCounter = 0
-    winnerAnimationInterval?: NodeJS.Timer
+    winnerAnimationInterval?: NodeJS.Timeout | undefined
 
     private v = new Vector3()
     private cameraPivot = new Object3D()

--- a/src/client/game.ts
+++ b/src/client/game.ts
@@ -61,7 +61,7 @@ export default class Game {
 
     socket = io()
     myId = ''
-    updateInterval?: NodeJS.Timer //used to update server
+    updateInterval?:  NodeJS.Timeout | undefined //used to update server
     timestamp = 0
     players: { [id: string]: Player } = {}
 

--- a/src/client/ui.ts
+++ b/src/client/ui.ts
@@ -4,7 +4,7 @@ import Game from './game'
 export default class UI {
     keyMap: { [id: string]: boolean } = {}
     timerValue = 0
-    timerInterval?: NodeJS.Timer
+    timerInterval?: NodeJS.Timeout | undefined
     startButton0 = document.getElementById('startButton0') as HTMLButtonElement
     startButton1 = document.getElementById('startButton1') as HTMLButtonElement
     startButton2 = document.getElementById('startButton2') as HTMLButtonElement


### PR DESCRIPTION
Problem:

The code was causing a TypeScript error because clearInterval expects an argument of type number | undefined, but this.timerInterval was typed as NodeJS.Timer. This mismatch was causing the following error:

No overload matches this call.
  Overload 1 of 2, '(intervalId: string | number | Timeout | undefined): void', gave the following error.
    Argument of type 'NodeJS.Timer' is not assignable to parameter of type 'string | number | Timeout | undefined'.

Solution:

The issue was resolved by updating the type of timerInterval to NodeJS.Timeout | undefined, which is the correct type for the return value of setInterval in a Node.js environment. This ensures compatibility with clearInterval and eliminates the TypeScript error.

This change ensures that the type of timerInterval is compatible with what clearInterval expects, preventing type errors during compilation.